### PR TITLE
Upgrade alpine to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk add --no-cache iproute2
 ENV DNSMASQ_PORT=53
 ENV NET_OVERLAY_IF=weave
-ADD . .
+COPY weave-tc.sh .
 ENTRYPOINT ./weave-tc.sh


### PR DESCRIPTION
Alpine 3.7 is somewhat old, and contains a couple BusyBox vulnerabilities that trip up our image scanners ([CVE-2018-20679](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-20679) and [CVE-2019-5747](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-5747) if you're curious).

This PR updates to the latest Alpine 3.9 base image, which includes fixes for these.

Also I updated the `ADD` line to use `COPY` instead, and explicitly only copied in the shell script (no need for the image to contain the other files in the repo).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>